### PR TITLE
Implement a VirtualServerCommandSource for specifying a custom set of roles

### DIFF
--- a/api/src/main/java/dev/gegy/roles/api/RoleOwner.java
+++ b/api/src/main/java/dev/gegy/roles/api/RoleOwner.java
@@ -1,0 +1,12 @@
+package dev.gegy.roles.api;
+
+/**
+ * Can be implemented on custom {@link net.minecraft.entity.Entity Entities} or
+ * {@link net.minecraft.server.command.ServerCommandSource ServerCommandSources}
+ * to allow overriding the set of roles that the entity/source is assumed to have.
+ *
+ * @see VirtualServerCommandSource
+ */
+public interface RoleOwner {
+    RoleReader getRoles();
+}

--- a/api/src/main/java/dev/gegy/roles/api/VirtualServerCommandSource.java
+++ b/api/src/main/java/dev/gegy/roles/api/VirtualServerCommandSource.java
@@ -21,11 +21,7 @@ public class VirtualServerCommandSource extends ServerCommandSource {
     private final RoleReader roles;
 
     public VirtualServerCommandSource(RoleReader roles, CommandOutput output, Vec3d pos, Vec2f rot, ServerWorld world, int level, String simpleName, Text name, MinecraftServer server, @Nullable Entity entity) {
-        this(roles, output, pos, rot, world, level, simpleName, name, server, entity, false, (context, success, result) -> {}, EntityAnchorArgumentType.EntityAnchor.FEET);
-    }
-
-    protected VirtualServerCommandSource(RoleReader roles, CommandOutput output, Vec3d pos, Vec2f rot, ServerWorld world, int level, String simpleName, Text name, MinecraftServer server, @Nullable Entity entity, boolean silent, ResultConsumer<ServerCommandSource> consumer, EntityAnchorArgumentType.EntityAnchor entityAnchor) {
-        super(output, pos, rot, world, level, simpleName, name, server, entity, silent, consumer, entityAnchor);
+        super(output, pos, rot, world, level, simpleName, name, server, entity, false, (context, success, result) -> {}, EntityAnchorArgumentType.EntityAnchor.FEET);
         this.roles = roles;
     }
 

--- a/api/src/main/java/dev/gegy/roles/api/VirtualServerCommandSource.java
+++ b/api/src/main/java/dev/gegy/roles/api/VirtualServerCommandSource.java
@@ -1,6 +1,5 @@
 package dev.gegy.roles.api;
 
-import com.mojang.brigadier.ResultConsumer;
 import net.minecraft.command.argument.EntityAnchorArgumentType;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.MinecraftServer;
@@ -13,11 +12,11 @@ import net.minecraft.util.math.Vec3d;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * An extension of {@link ServerCommandSource} that allows specifying a
- * custom list of roles to use instead of the default empty set when no
+ * An extension of {@link ServerCommandSource} that implements {@link RoleOwner}
+ * to allow a custom list of roles to use instead of the default empty set when no
  * entity is passed.
  */
-public class VirtualServerCommandSource extends ServerCommandSource {
+public class VirtualServerCommandSource extends ServerCommandSource implements RoleOwner {
     private final RoleReader roles;
 
     public VirtualServerCommandSource(RoleReader roles, CommandOutput output, Vec3d pos, Vec2f rot, ServerWorld world, int level, String simpleName, Text name, MinecraftServer server, @Nullable Entity entity) {
@@ -25,6 +24,7 @@ public class VirtualServerCommandSource extends ServerCommandSource {
         this.roles = roles;
     }
 
+    @Override
     public RoleReader getRoles() {
         return this.roles;
     }

--- a/api/src/main/java/dev/gegy/roles/api/VirtualServerCommandSource.java
+++ b/api/src/main/java/dev/gegy/roles/api/VirtualServerCommandSource.java
@@ -1,0 +1,35 @@
+package dev.gegy.roles.api;
+
+import com.mojang.brigadier.ResultConsumer;
+import net.minecraft.command.argument.EntityAnchorArgumentType;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.CommandOutput;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.Vec2f;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An extension of {@link ServerCommandSource} that allows specifying a
+ * custom list of roles to use instead of the default empty set when no
+ * entity is passed.
+ */
+public class VirtualServerCommandSource extends ServerCommandSource {
+    private final RoleReader roles;
+
+    public VirtualServerCommandSource(RoleReader roles, CommandOutput output, Vec3d pos, Vec2f rot, ServerWorld world, int level, String simpleName, Text name, MinecraftServer server, @Nullable Entity entity) {
+        this(roles, output, pos, rot, world, level, simpleName, name, server, entity, false, (context, success, result) -> {}, EntityAnchorArgumentType.EntityAnchor.FEET);
+    }
+
+    protected VirtualServerCommandSource(RoleReader roles, CommandOutput output, Vec3d pos, Vec2f rot, ServerWorld world, int level, String simpleName, Text name, MinecraftServer server, @Nullable Entity entity, boolean silent, ResultConsumer<ServerCommandSource> consumer, EntityAnchorArgumentType.EntityAnchor entityAnchor) {
+        super(output, pos, rot, world, level, simpleName, name, server, entity, silent, consumer, entityAnchor);
+        this.roles = roles;
+    }
+
+    public RoleReader getRoles() {
+        return this.roles;
+    }
+}

--- a/src/main/java/dev/gegy/roles/PlayerRoles.java
+++ b/src/main/java/dev/gegy/roles/PlayerRoles.java
@@ -1,10 +1,7 @@
 package dev.gegy.roles;
 
 import com.mojang.serialization.Codec;
-import dev.gegy.roles.api.PlayerRolesApi;
-import dev.gegy.roles.api.RoleLookup;
-import dev.gegy.roles.api.RoleReader;
-import dev.gegy.roles.api.VirtualServerCommandSource;
+import dev.gegy.roles.api.*;
 import dev.gegy.roles.api.override.RoleOverrideType;
 import dev.gegy.roles.command.RoleCommand;
 import dev.gegy.roles.config.PlayerRolesConfig;
@@ -59,6 +56,11 @@ public final class PlayerRoles implements ModInitializer {
                 if (entity instanceof PlayerWithRoles player) {
                     return player.getPlayerRoleSet();
                 }
+
+                if (entity instanceof RoleOwner roleOwner) {
+                    return roleOwner.getRoles();
+                }
+
                 return RoleReader.EMPTY;
             }
 
@@ -70,8 +72,8 @@ public final class PlayerRoles implements ModInitializer {
                     return this.byEntity(entity);
                 }
 
-                if (source instanceof VirtualServerCommandSource virtualSource) {
-                    return virtualSource.getRoles();
+                if (source instanceof RoleOwner roleOwner) {
+                    return roleOwner.getRoles();
                 }
 
                 if (source instanceof IdentifiableCommandSource identifiable) {

--- a/src/main/java/dev/gegy/roles/PlayerRoles.java
+++ b/src/main/java/dev/gegy/roles/PlayerRoles.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.Codec;
 import dev.gegy.roles.api.PlayerRolesApi;
 import dev.gegy.roles.api.RoleLookup;
 import dev.gegy.roles.api.RoleReader;
+import dev.gegy.roles.api.VirtualServerCommandSource;
 import dev.gegy.roles.api.override.RoleOverrideType;
 import dev.gegy.roles.command.RoleCommand;
 import dev.gegy.roles.config.PlayerRolesConfig;
@@ -67,6 +68,10 @@ public final class PlayerRoles implements ModInitializer {
                 var entity = source.getEntity();
                 if (entity != null) {
                     return this.byEntity(entity);
+                }
+
+                if (source instanceof VirtualServerCommandSource virtualSource) {
+                    return virtualSource.getRoles();
                 }
 
                 if (source instanceof IdentifiableCommandSource identifiable) {


### PR DESCRIPTION
Implements a subclass of `ServerCommandSource` that allows other mods to specify a custom `RoleReader` to be used if it is not representing an `Entity`.

This can be used mods such as Discord bridges, which could generate a list of in-game roles based on those a user has on Discord, to allow different levels of command privilege (eg. Discord admins can run `/stop` via the bridge, but moderators cannot)