### PR TITLE
Fix role autocompletion giving only higher roles

### DIFF
--- a/src/main/java/dev/gegy/roles/command/RoleCommand.java
+++ b/src/main/java/dev/gegy/roles/command/RoleCommand.java
@@ -165,7 +165,7 @@ public final class RoleCommand {
 
             return CommandSource.suggestMatching(
                     PlayerRolesConfig.get().stream()
-                            .filter(role -> admin || comparator.compare(role, highestRole) < 0)
+                            .filter(role -> admin || comparator.compare(role, highestRole) > 0)
                             .map(Role::getId),
                     builder
             );


### PR DESCRIPTION
This tiny change fixes an amusing issue where in the case of a non-admin role giver, instead of getting suggestions for only lower-level roles, they get only higher-level ones, which are exactly the ones that they can't give at all