### PR TITLE
Add `role` entity selector option

### DIFF
--- a/src/main/java/dev/gegy/roles/command/ExtendedEntitySelectorReader.java
+++ b/src/main/java/dev/gegy/roles/command/ExtendedEntitySelectorReader.java
@@ -1,0 +1,6 @@
+package dev.gegy.roles.command;
+
+public interface ExtendedEntitySelectorReader {
+    boolean selectsRole();
+    void setSelectsRole(boolean value);
+}

--- a/src/main/java/dev/gegy/roles/mixin/EntitySelectorOptionsMixin.java
+++ b/src/main/java/dev/gegy/roles/mixin/EntitySelectorOptionsMixin.java
@@ -1,0 +1,39 @@
+package dev.gegy.roles.mixin;
+
+import dev.gegy.roles.api.PlayerRolesApi;
+import dev.gegy.roles.command.ExtendedEntitySelectorReader;
+import net.minecraft.command.EntitySelectorOptions;
+import net.minecraft.command.EntitySelectorReader;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.Predicate;
+
+@Mixin(EntitySelectorOptions.class)
+public abstract class EntitySelectorOptionsMixin {
+    @Shadow private static void putOption(String id, EntitySelectorOptions.SelectorHandler handler, Predicate<EntitySelectorReader> condition, Text description) {
+    }
+
+    @Inject(method = "register", at = @At(value = "INVOKE", target = "Lnet/minecraft/command/EntitySelectorOptions;putOption(Ljava/lang/String;Lnet/minecraft/command/EntitySelectorOptions$SelectorHandler;Ljava/util/function/Predicate;Lnet/minecraft/text/Text;)V", ordinal = 0))
+    private static void registerRoleSelector(CallbackInfo ci) {
+        putOption("role",
+                reader -> {
+                    boolean isNegated = reader.readNegationCharacter();
+                    String roleName = reader.getReader().readUnquotedString();
+                    reader.setPredicate(entity -> {
+                        var role = PlayerRolesApi.provider().get(roleName);
+                        return (role != null && PlayerRolesApi.lookup().byEntity(entity).has(role)) != isNegated;
+                    });
+                    if (!isNegated) {
+                        ((ExtendedEntitySelectorReader)reader).setSelectsRole(true);
+                    }
+                },
+                reader -> !((ExtendedEntitySelectorReader)reader).selectsRole(),
+                Text.literal("Player Role")
+        );
+    }
+}

--- a/src/main/java/dev/gegy/roles/mixin/EntitySelectorReaderMixin.java
+++ b/src/main/java/dev/gegy/roles/mixin/EntitySelectorReaderMixin.java
@@ -1,0 +1,20 @@
+package dev.gegy.roles.mixin;
+
+import dev.gegy.roles.command.ExtendedEntitySelectorReader;
+import net.minecraft.command.EntitySelectorReader;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(EntitySelectorReader.class)
+public class EntitySelectorReaderMixin implements ExtendedEntitySelectorReader {
+    private boolean selectsRole = false;
+
+    @Override
+    public boolean selectsRole() {
+        return this.selectsRole;
+    }
+
+    @Override
+    public void setSelectsRole(boolean value) {
+        this.selectsRole = value;
+    }
+}

--- a/src/main/resources/roles.mixins.json
+++ b/src/main/resources/roles.mixins.json
@@ -6,6 +6,8 @@
   "mixins": [
     "CommandBlockExecutorMixin",
     "CommandFunctionMixin",
+    "EntitySelectorOptionsMixin",
+    "EntitySelectorReaderMixin",
     "PlayerManagerMixin",
     "ServerCommandSourceMixin",
     "ServerPlayerEntityMixin",


### PR DESCRIPTION
This PR adds a `role` entity selector option, as asked for in #40.

Here is an example of usage:
![Screenshot_20220902_222030](https://user-images.githubusercontent.com/5115825/188236941-bca9dea8-fd4d-4cdd-88de-cc7738ede4ce.png)

Negation is supported, too:

![Screenshot_20220902_222117](https://user-images.githubusercontent.com/5115825/188237011-8db0b36d-fb0b-44fc-9f52-d164f728f1b6.png)

Multiple negated selections can be used; only one non-negated selection can be used.

Unfortunately, entity selector options are not synced to the client, so a vanilla client will see them as invalid:
![Screenshot_20220902_221347](https://user-images.githubusercontent.com/5115825/188236714-b6629a2d-0d12-4a02-85bf-7b7aea8a1357.png)

However, they still work fine when executed.