### PR TITLE
Add a `bypass_player_limit` role override

### DIFF
--- a/src/main/java/dev/gegy/roles/PlayerRoles.java
+++ b/src/main/java/dev/gegy/roles/PlayerRoles.java
@@ -18,6 +18,7 @@ import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.message.v1.ServerMessageEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.entity.Entity;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
@@ -26,6 +27,8 @@ import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
 
 public final class PlayerRoles implements ModInitializer {
     public static final String ID = "player_roles";
@@ -47,6 +50,7 @@ public final class PlayerRoles implements ModInitializer {
     public static final RoleOverrideType<Boolean> MUTE = registerOverride("mute", Codec.BOOL);
     public static final RoleOverrideType<Integer> PERMISSION_LEVEL = registerOverride("permission_level", Codec.intRange(0, 4));
     public static final RoleOverrideType<Boolean> ENTITY_SELECTORS = registerOverride("entity_selectors", Codec.BOOL);
+    public static final RoleOverrideType<Boolean> BYPASS_PLAYER_LIMIT = registerOverride("bypass_player_limit", Codec.BOOL);
 
     private static <T> RoleOverrideType<T> registerOverride(String id, Codec<T> codec) {
         return RoleOverrideType.register(PlayerRoles.identifier(id), codec);
@@ -139,6 +143,10 @@ public final class PlayerRoles implements ModInitializer {
             return false;
         }
         return true;
+    }
+
+    public static boolean canBypassPlayerLimit(MinecraftServer server, UUID playerUuid) {
+        return PlayerRoleManager.get().peekRoles(server, playerUuid).overrides().test(PlayerRoles.BYPASS_PLAYER_LIMIT);
     }
 
     public static Identifier identifier(String path) {

--- a/src/main/java/dev/gegy/roles/mixin/bypass_limit/DedicatedPlayerManagerMixin.java
+++ b/src/main/java/dev/gegy/roles/mixin/bypass_limit/DedicatedPlayerManagerMixin.java
@@ -1,0 +1,30 @@
+package dev.gegy.roles.mixin.bypass_limit;
+
+import com.mojang.authlib.GameProfile;
+import dev.gegy.roles.PlayerRoles;
+import net.minecraft.registry.CombinedDynamicRegistries;
+import net.minecraft.registry.ServerDynamicRegistryType;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.dedicated.DedicatedPlayerManager;
+import net.minecraft.world.WorldSaveHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(DedicatedPlayerManager.class)
+public class DedicatedPlayerManagerMixin extends PlayerManager {
+    public DedicatedPlayerManagerMixin(MinecraftServer server, CombinedDynamicRegistries<ServerDynamicRegistryType> registryManager, WorldSaveHandler saveHandler, int maxPlayers) {
+        super(server, registryManager, saveHandler, maxPlayers);
+    }
+
+    @Inject(method = "canBypassPlayerLimit", at = @At("HEAD"), cancellable = true)
+    private void canPlayerBypassLimitWithRole(GameProfile profile, CallbackInfoReturnable<Boolean> cir) {
+        if (profile.getId() != null) {
+            if (PlayerRoles.canBypassPlayerLimit(this.getServer(), profile.getId())) {
+                cir.setReturnValue(true);
+            }
+        }
+    }
+}

--- a/src/main/resources/roles.mixins.json
+++ b/src/main/resources/roles.mixins.json
@@ -12,6 +12,7 @@
     "ServerCommandSourceMixin",
     "ServerPlayerEntityMixin",
     "TeamAccessor",
+    "bypass_limit.DedicatedPlayerManagerMixin",
     "chat_type.ServerPlayNetworkHandlerMixin",
     "command.CommandDispatcherMixin",
     "command.CommandManagerMixin",


### PR DESCRIPTION
# Motivation

Sometimes, a server should allow staff to join even when it is at capacity for regular players. While vanilla allows this as an option for operators (though requiring editing ops.json manually), it is useful to do this on a per-role basis too.

# Content

This PR adds a new boolean role override, `bypass_player_limit`. Players whose roles have this set to true can join the Minecraft server even when it is at player capacity.