### PR TITLE
Fix POM dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,12 +45,7 @@ allprojects {
       publications {
         mavenJava(MavenPublication) {
           artifactId = project.archivesBaseName
-          artifact(remapJar) {
-            builtBy remapJar
-          }
-          artifact(sourcesJar) {
-            builtBy remapSourcesJar
-          }
+          from components.java
         }
       }
 


### PR DESCRIPTION
Right now, transitive dependencies don't properly work, as you haven't updated to the new way of doing `from components.java` when Loom switched to that.
(It may also make sense to update Gradle and Loom but that's out of scope for this PR)