### PR TITLE
Fix permission level during login

### DIFF
--- a/src/main/java/dev/gegy/roles/mixin/permission_level/MinecraftServerMixin.java
+++ b/src/main/java/dev/gegy/roles/mixin/permission_level/MinecraftServerMixin.java
@@ -2,29 +2,21 @@ package dev.gegy.roles.mixin.permission_level;
 
 import com.mojang.authlib.GameProfile;
 import dev.gegy.roles.PlayerRoles;
-import dev.gegy.roles.api.PlayerRolesApi;
+import dev.gegy.roles.store.PlayerRoleManager;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.PlayerManager;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(MinecraftServer.class)
 public abstract class MinecraftServerMixin {
-    @Shadow
-    public abstract PlayerManager getPlayerManager();
-
     @Inject(method = "getPermissionLevel", at = @At("HEAD"), cancellable = true)
     public void getPermissionLevel(GameProfile profile, CallbackInfoReturnable<Integer> ci) {
-        var player = this.getPlayerManager().getPlayer(profile.getId());
-        if (player != null) {
-            var roles = PlayerRolesApi.lookup().byPlayer(player);
-            var permissionLevel = roles.overrides().select(PlayerRoles.PERMISSION_LEVEL);
-            if (permissionLevel != null) {
-                ci.setReturnValue(permissionLevel);
-            }
+        var roles = PlayerRoleManager.get().peekRoles((MinecraftServer)(Object)this, profile.getId());
+        var permissionLevel = roles.overrides().select(PlayerRoles.PERMISSION_LEVEL);
+        if (permissionLevel != null) {
+            ci.setReturnValue(permissionLevel);
         }
     }
 }


### PR DESCRIPTION
This fix is needed because the permission level is checked early in the login process, before the player is actually added to the player manager. This would also allow compatibility with any mod that uses this method for offline players for any reason.

It fixes the issues we ran into at ModFest 1.20. If you have a command that you're allowed to use due to your permission level it now suggests correctly without you having to die first