### PR TITLE
Fix online player roles being cleared when reloading roles

### DIFF
--- a/src/main/java/dev/gegy/roles/store/PlayerRoleSet.java
+++ b/src/main/java/dev/gegy/roles/store/PlayerRoleSet.java
@@ -128,7 +128,7 @@ public final class PlayerRoleSet implements RoleReader {
     }
 
     public void reloadFrom(RoleProvider roleProvider, PlayerRoleSet roles) {
-        var names = this.roles.stream().map(Role::getId).toList();
+        var names = roles.stream().map(Role::getId).toList();
         this.deserialize(roleProvider, names);
 
         this.dirty |= roles.dirty;


### PR DESCRIPTION
An issue introduced in #101 caused `/role reload` to clear the roles of any online players.

Fixes #103